### PR TITLE
Add `files` property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,11 @@
   },
   "scripts": {
     "test": "node test/index.js"
-  }
+  },
+  "files": [
+    "bin/",
+    "LICENSE.BSD",
+    "parser.js",
+    "README.md"
+  ]
 }


### PR DESCRIPTION
This ensures that the npm package only contains what is really needed.
