### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+charset = utf-8


### PR DESCRIPTION
http://editorconfig.org/

This saves me (and everyone else) from having to switch my editor to 2-space indents every time I start working on regjsparser.
