### PR TITLE
Remove the upper limit of hex digits in Unicode code point escapes

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -706,7 +706,7 @@
         return parseUnicodeSurrogatePairEscape(
           createEscaped('unicodeEscape', parseInt(res[1], 16), res[1], 2)
         );
-      } else if (hasUnicodeFlag && (res = matchReg(/^u\{([0-9a-fA-F]{1,6})\}/))) {
+      } else if (hasUnicodeFlag && (res = matchReg(/^u\{([0-9a-fA-F]{1,})\}/))) {
         // RegExpUnicodeEscapeSequence (ES6 Unicode code point escape)
         return createEscaped('unicodeCodePointEscape', parseInt(res[1], 16), res[1], 4);
       } else {

--- a/test/test-data-unicode.json
+++ b/test/test-data-unicode.json
@@ -9,6 +9,16 @@
     ],
     "raw": "\\u{000000}"
   },
+  "\\u{0000000000000000000}": {
+    "type": "value",
+    "kind": "unicodeCodePointEscape",
+    "codePoint": 0,
+    "range": [
+      0,
+      23
+    ],
+    "raw": "\\u{0000000000000000000}"
+  },
   "\\u{0}": {
     "type": "value",
     "kind": "unicodeCodePointEscape",


### PR DESCRIPTION
There is no limit to the number of hex digits in a Unicode code point escape sequence in the spec. The only limit is the value cannot exceed `10FFFF`. E.g. `'\u{00000000000000000001D306}' == '\u{1D306}'`.
