### PR TITLE
Fix #70: Perform second parse if needed to be spec compliant

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -916,8 +916,8 @@
 
     // The spec requires to interpret the `\2` in `/\2()()/` as backreference.
     // As the parser collects the number of capture groups as the string is
-    // parsed it is impossible to making these decisions at the point the `\2`
-    // handled. In case the local decision turns out to be wrong later after the
+    // parsed it is impossible to make these decisions at the point the `\2` is
+    // handled. In case the local decision turns out to be wrongq after the
     // parsing has finished, the input string is parsed a second time with the
     // total count of capture groups set.
     //

--- a/test/test-data.json
+++ b/test/test-data.json
@@ -4252,9 +4252,8 @@
     "behavior": "normal",
     "body": [
       {
-        "type": "value",
-        "kind": "octal",
-        "codePoint": 1,
+        "type": "reference",
+        "matchIndex": 1,
         "range": [
           1,
           3
@@ -36579,5 +36578,167 @@
       3
     ],
     "raw": "|.|"
+  },
+  "(\\1)+\\1\\1": {
+    "type": "alternative",
+    "body": [
+      {
+        "type": "quantifier",
+        "min": 1,
+        "max": null,
+        "greedy": true,
+        "body": [
+          {
+            "type": "group",
+            "behavior": "normal",
+            "body": [
+              {
+                "type": "reference",
+                "matchIndex": 1,
+                "range": [
+                  1,
+                  3
+                ],
+                "raw": "\\1"
+              }
+            ],
+            "range": [
+              0,
+              4
+            ],
+            "raw": "(\\1)"
+          }
+        ],
+        "range": [
+          0,
+          5
+        ],
+        "raw": "(\\1)+"
+      },
+      {
+        "type": "reference",
+        "matchIndex": 1,
+        "range": [
+          5,
+          7
+        ],
+        "raw": "\\1"
+      },
+      {
+        "type": "reference",
+        "matchIndex": 1,
+        "range": [
+          7,
+          9
+        ],
+        "raw": "\\1"
+      }
+    ],
+    "range": [
+      0,
+      9
+    ],
+    "raw": "(\\1)+\\1\\1"
+  },
+  "(\\1)a": {
+    "type": "alternative",
+    "body": [
+      {
+        "type": "group",
+        "behavior": "normal",
+        "body": [
+          {
+            "type": "reference",
+            "matchIndex": 1,
+            "range": [
+              1,
+              3
+            ],
+            "raw": "\\1"
+          }
+        ],
+        "range": [
+          0,
+          4
+        ],
+        "raw": "(\\1)"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 97,
+        "range": [
+          4,
+          5
+        ],
+        "raw": "a"
+      }
+    ],
+    "range": [
+      0,
+      5
+    ],
+    "raw": "(\\1)a"
+  },
+  "(\\2)(b)a": {
+    "type": "alternative",
+    "body": [
+      {
+        "type": "group",
+        "behavior": "normal",
+        "body": [
+          {
+            "type": "reference",
+            "matchIndex": 2,
+            "range": [
+              1,
+              3
+            ],
+            "raw": "\\2"
+          }
+        ],
+        "range": [
+          0,
+          4
+        ],
+        "raw": "(\\2)"
+      },
+      {
+        "type": "group",
+        "behavior": "normal",
+        "body": [
+          {
+            "type": "value",
+            "kind": "symbol",
+            "codePoint": 98,
+            "range": [
+              5,
+              6
+            ],
+            "raw": "b"
+          }
+        ],
+        "range": [
+          4,
+          7
+        ],
+        "raw": "(b)"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 97,
+        "range": [
+          7,
+          8
+        ],
+        "raw": "a"
+      }
+    ],
+    "range": [
+      0,
+      8
+    ],
+    "raw": "(\\2)(b)a"
   }
 }


### PR DESCRIPTION
\r? @mathiasbynens, @d10 