### PR TITLE
Adding bail error output in case the parser gets stuck

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -926,7 +926,7 @@
     var result = parseDisjunction();
 
     if (result.range[1] !== str.length) {
-      throw SyntaxError('Could not parse entire input - got stuck: ' + str);
+      bail('Could not parse entire input - got stuck', '', result.range[1]);
     }
 
     // The spec requires to interpret the `\2` in `/\2()()/` as backreference.

--- a/test/test-data.json
+++ b/test/test-data.json
@@ -4712,7 +4712,7 @@
   ")*": {
     "type": "error",
     "name": "SyntaxError",
-    "message": "Could not parse entire input - got stuck: )*",
+    "message": "Could not parse entire input - got stuck at position 0\n    )*\n    ^",
     "input": ")*"
   },
   "**a": {
@@ -30228,7 +30228,7 @@
   "\\": {
     "type": "error",
     "name": "SyntaxError",
-    "message": "Could not parse entire input - got stuck: \\",
+    "message": "Could not parse entire input - got stuck at position 2\n    \\\n      ^",
     "input": "\\"
   },
   "\\!": {


### PR DESCRIPTION
Followup of #74.

@kpdecker - can you maybe take a look at this and do a quick review?

In particular, is there a reason the "Could not parse entire input" message was not converted to the new `bail(...)` function?

Thanks!