### PR TITLE
bin: Add -v/--version and -f/--flags options

### DIFF
--- a/bin/parser
+++ b/bin/parser
@@ -2,17 +2,21 @@
 (function() {
 
   var fs = require('fs');
+  var path = require('path');
   var parse = require('../parser').parse;
   var jsesc = require('jsesc');
   var regexes = process.argv.splice(2);
   var first = regexes[0];
   var data;
   var log = console.log;
+  var flags = '';
   var main = function() {
     if (/^(?:-h|--help|undefined)$/.test(first)) {
       log([
         '\nUsage:\n',
         '\tregjsparser [regex ...]',
+        '\tregjsparser [-f | --flags] u [regex ...]',
+        '\tregjsparser [-v | --version]',
         '\tregjsparser [-h | --help]',
         '\nExamples:\n',
         '\tregjsparser \'^foo.bar$\'',
@@ -21,10 +25,19 @@
       return process.exit(1);
     }
 
+    if (/^(?:-v|--version)$/.test(first)) {
+      log('v%s', require(path.resolve(__dirname, '../package.json')).version);
+      return process.exit(1);
+    }
+
+    if (/^(?:-f|--flags)$/.test(first)) {
+      flags = regexes[1];
+      regexes = regexes.slice(2);
+    }
+
     regexes.forEach(function(snippet) {
-      var result;
       try {
-        result = parse(snippet, 'u');
+        result = parse(snippet, flags);
         log(jsesc(result, {
           'json': true,
           'compact': false,


### PR DESCRIPTION
Ref. https://github.com/jviereck/regjsparser/commit/f06617921694722a2de013c57efa84da650ed013#comments

``` bash
$ regjsparser '\u{1D306}'
Expected atom at position 2
    \u{1D306}
      ^

Error: failed to parse. Make sure the regular expression is valid.
If you think this is a bug in regjsparser, please report it:
    https://github.com/jviereck/regjsparser/issues/new

Stack trace:

SyntaxError: Expected atom at position 2
    \u{1D306}
      ^
    at SyntaxError (native)
    at bail (~/projects/regjsparser/parser.js:923:13)
    at parseTerm (~/projects/regjsparser/parser.js:403:9)
    at parseAlternative (~/projects/regjsparser/parser.js:374:21)
    at parseDisjunction (~/projects/regjsparser/parser.js:354:16)
    at parse (~/projects/regjsparser/parser.js:938:18)
    at ~/projects/regjsparser/bin/parser:40:18
    at Array.forEach (native)
    at main (~/projects/regjsparser/bin/parser:38:13)
    at ~/projects/regjsparser/bin/parser:61:3
```

``` bash
$ regjsparser --flags 'u' '\u{1D306}'
{
    "type": "value",
    "kind": "unicodeCodePointEscape",
    "codePoint": 119558,
    "range": [
        0,
        9
    ],
    "raw": "\\u{1D306}"
}
```
