### PR TITLE
Minor, updated the README.md docs to show how to use the two features

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ var parse = require('regjsparser').parse;
 
 var parseTree = parse('^a'); // /^a/
 console.log(parseTree);
+
+// Toggle on/off additional features:
+var parseTree = parse('^a', {
+  // SEE: https://github.com/jviereck/regjsparser/pull/78
+  unicodePropertyEscape: true,
+
+  // SEE: https://github.com/jviereck/regjsparser/pull/83
+  namedGroups: true
+});
+console.log(parseTree);
 ```
 
 ## Testing


### PR DESCRIPTION
Minor, updated the README.md docs to show how to use the two features (`unicodePropertyEscape` and `namedGroups`).

I also went over the changes in #83 and #84. To my believe all open followup points are adressed. If I don't hear a veto, I am going to create a new release after this PR lands.

\review: @mathiasbynens, @nicolo-ribaudo  ?
