### PR TITLE
fix: update IdentityEscape grammar

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -955,6 +955,9 @@
         (hasUnicodeFlag && /[\^\$\.\*\+\?\(\)\\\[\]\{\}\|\/]/.test(l)) ||
         (!hasUnicodeFlag && l !== "c")
       ) {
+        if (l === "k" && features.lookbehind) {
+          return null;
+        }
         tmp = incr();
         return createEscaped('identifier', tmp.charCodeAt(0), tmp, 1);
       }

--- a/parser.js
+++ b/parser.js
@@ -941,11 +941,20 @@
 
     function parseIdentityEscape() {
       // IdentityEscape ::
-      //      SourceCharacter but not c
+      //      [+U] SyntaxCharacter
+      //      [+U] /
+      //      [~U] SourceCharacterIdentityEscape[?N]
+      // SourceCharacterIdentityEscape[?N] ::
+      //      [~N] SourceCharacter but not c
+      //      [+N] SourceCharacter but not one of c or k
+
 
       var tmp;
-
-      if (lookahead() !== 'c') {
+      var l = lookahead();
+      if (
+        (hasUnicodeFlag && /[\^\$\.\*\+\?\(\)\\\[\]\{\}\|\/]/.test(l)) ||
+        (!hasUnicodeFlag && l !== "c")
+      ) {
         tmp = incr();
         return createEscaped('identifier', tmp.charCodeAt(0), tmp, 1);
       }

--- a/test/test-data-lookbehind.json
+++ b/test/test-data-lookbehind.json
@@ -346,5 +346,11 @@
       6
     ],
     "raw": "(?<!.)"
+  },
+  "\\k": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "atomEscape at position 1\n    \\k\n     ^",
+    "input": "\\k"
   }
 }

--- a/test/test-data-unicode-properties.json
+++ b/test/test-data-unicode-properties.json
@@ -182,13 +182,13 @@
   "\\p{}": {
     "type": "error",
     "name": "SyntaxError",
-    "message": "Expected atom at position 2\n    \\p{}\n      ^",
+    "message": "atomEscape at position 1\n    \\p{}\n     ^",
     "input": "\\p{}"
   },
   "\\P{}": {
     "type": "error",
     "name": "SyntaxError",
-    "message": "Expected atom at position 2\n    \\P{}\n      ^",
+    "message": "atomEscape at position 1\n    \\P{}\n     ^",
     "input": "\\P{}"
   }
 }

--- a/test/test-data-unicode.json
+++ b/test/test-data-unicode.json
@@ -898,5 +898,11 @@
     "name": "SyntaxError",
     "message": "Invalid escape sequence at position 1\n    \\u{110000}\n     ^",
     "input": "\\u{110000}"
+  },
+  "\\a": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "atomEscape at position 1\n    \\a\n     ^",
+    "input": "\\a"
   }
 }

--- a/test/test-data.json
+++ b/test/test-data.json
@@ -37424,5 +37424,25 @@
       8
     ],
     "raw": "(\\2)(b)a"
+  },
+  "\\a": {
+    "type": "value",
+    "kind": "identifier",
+    "codePoint": 97,
+    "range": [
+      0,
+      2
+    ],
+    "raw": "\\a"
+  },
+  "\\k": {
+    "type": "value",
+    "kind": "identifier",
+    "codePoint": 107,
+    "range": [
+      0,
+      2
+    ],
+    "raw": "\\k"
   }
 }


### PR DESCRIPTION
Fixes #66 

Update `parseIdentityEscape` to the following grammar
```
 IdentityEscape ::
      SourceCharacter but not c	      
      [+U] SyntaxCharacter
      [+U] /
      [~U] SourceCharacterIdentityEscape[?N]

 SourceCharacterIdentityEscape[?N] ::
      [~N] SourceCharacter but not c
      [+N] SourceCharacter but not one of c or k
```