### PR TITLE
Add test for /a./

### DIFF
--- a/test/test-data.json
+++ b/test/test-data.json
@@ -37444,5 +37444,33 @@
       2
     ],
     "raw": "\\k"
+  },
+  "a.": {
+    "type": "alternative",
+    "body": [
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 97,
+        "range": [
+          0,
+          1
+        ],
+        "raw": "a"
+      },
+      {
+        "type": "dot",
+        "range": [
+          1,
+          2
+        ],
+        "raw": "."
+      }
+    ],
+    "range": [
+      0,
+      2
+    ],
+    "raw": "a."
   }
 }


### PR DESCRIPTION
In https://github.com/mathiasbynens/regexpu-core/pull/29#issuecomment-533523513 I found a bug in `regjsgen`.
I fixed it (https://github.com/bnjmnt4n/regjsgen/pull/13), but when I wanted to add a test I found out that it downloads the test from this reporitory. Even if it's not a bug with your package, I think that a test for a previously untested behavior could be accepted? :stuck_out_tongue: 