### PR TITLE
allow - in classEscape when unicode flag is enabled

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -706,6 +706,7 @@
 
       // For ClassEscape
       if (insideCharacterClass) {
+        //     b
         if (match('b')) {
           // 15.10.2.19
           // The production ClassEscape :: b evaluates by returning the
@@ -717,6 +718,10 @@
           // B.1.4
           // c ClassControlLetter
           return createEscaped('controlLetter', res[1] + 16, res[1], 2);
+        }
+        //     [+U] -
+        if (match('-') && hasUnicodeFlag) {
+          return createEscaped('singleEscape', 0x002d, '\\-');
         }
       }
 

--- a/test/test-data-unicode.json
+++ b/test/test-data-unicode.json
@@ -898,5 +898,20 @@
     "name": "SyntaxError",
     "message": "Invalid escape sequence at position 1\n    \\u{110000}\n     ^",
     "input": "\\u{110000}"
+  },
+  "[\\-]": {
+    "type": "characterClass",
+    "body": [
+      {
+        "type": "value",
+        "kind": "singleEscape",
+        "codePoint": 45,
+        "range": [1, 3],
+        "raw": "\\-"
+      }
+    ],
+    "negative": false,
+    "range": [0, 4],
+    "raw": "[\\-]"
   }
 }


### PR DESCRIPTION
Fixes #98 

Implements https://tc39.es/ecma262/#prod-annexB-ClassEscape
```
ClassEscape ::
    b
    [+U] -
    ...
```