### PR TITLE
Detect lone or unescaped brackets and braces when the unicode flag is set

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -233,6 +233,12 @@
       var _char = matches[0];
       var first = _char.charCodeAt(0);
       if (hasUnicodeFlag) {
+        if (_char === '}') {
+          bail("unescaped or unmatched closing brace");
+        }
+        if (_char === ']') {
+          bail("unescaped or unmatched closing bracket");
+        }
         var second;
         if (_char.length === 1 && first >= 0xD800 && first <= 0xDBFF) {
           second = lookahead().charCodeAt(0);

--- a/test/test-data-unicode.json
+++ b/test/test-data-unicode.json
@@ -905,6 +905,24 @@
     "message": "atomEscape at position 1\n    \\a\n     ^",
     "input": "\\a"
   },
+  "\\-": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "atomEscape at position 1\n    \\-\n     ^",
+    "input": "\\-"
+  },
+  "}": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "unescaped or unmatched closing brace at position 1\n    }\n     ^",
+    "input": "}"
+  },
+  "]": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "unescaped or unmatched closing bracket at position 1\n    ]\n     ^",
+    "input": "]"
+  },
   "[\\-]": {
     "type": "characterClass",
     "body": [


### PR DESCRIPTION
Hi @jviereck 

This fixes https://github.com/mathiasbynens/regexpu-core/issues/36 and thus https://github.com/babel/babel/issues/11138

Edit: force push for code styling reasons.