### PR TITLE
Fix regression with using closing brackets inside of class range in non-unicode mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regjsparser",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "author": "'Julian Viereck' <julian.viereck@gmail.com>",
   "license": "BSD-2-Clause",
   "main": "./parser",

--- a/parser.js
+++ b/parser.js
@@ -631,7 +631,7 @@
         //      PatternCharacter
         return createCharacter(res);
       }
-      else if (!hasUnicodeFlag && (res = matchReg(/^[^^$\\.*+?(){[|]/))) {
+      else if (!hasUnicodeFlag && (res = matchReg(/^(?:]|})/))) {
         //      ExtendedPatternCharacter
         return createCharacter(res);
       }

--- a/parser.js
+++ b/parser.js
@@ -229,14 +229,14 @@
       return createValue(kind, codePoint, pos - (value.length + fromOffset), pos);
     }
 
-    function createCharacter(matches) {
+    function createCharacter(matches, insideClass) {
       var _char = matches[0];
       var first = _char.charCodeAt(0);
       if (hasUnicodeFlag) {
-        if (_char === '}') {
+        if (!insideClass && _char === '}') {
           bail("unescaped or unmatched closing brace");
         }
-        if (_char === ']') {
+        if (!insideClass && _char === ']') {
           bail("unescaped or unmatched closing bracket");
         }
         var second;
@@ -1102,7 +1102,7 @@
 
       var res;
       if (res = matchReg(/^[^\\\]-]/)) {
-        return createCharacter(res[0]);
+        return createCharacter(res[0], true);
       } else if (match('\\')) {
         res = parseClassEscape();
         if (!res) {

--- a/test/test-data-unicode.json
+++ b/test/test-data-unicode.json
@@ -914,13 +914,13 @@
   "}": {
     "type": "error",
     "name": "SyntaxError",
-    "message": "unescaped or unmatched closing brace at position 1\n    }\n     ^",
+    "message": "Expected atom at position 0\n    }\n    ^",
     "input": "}"
   },
   "]": {
     "type": "error",
     "name": "SyntaxError",
-    "message": "unescaped or unmatched closing bracket at position 1\n    ]\n     ^",
+    "message": "Expected atom at position 0\n    ]\n    ^",
     "input": "]"
   },
   "[\\-]": {

--- a/test/test-data-unicode.json
+++ b/test/test-data-unicode.json
@@ -930,12 +930,60 @@
         "type": "value",
         "kind": "singleEscape",
         "codePoint": 45,
-        "range": [1, 3],
+        "range": [
+          1,
+          3
+        ],
         "raw": "\\-"
       }
     ],
     "negative": false,
-    "range": [0, 4],
+    "range": [
+      0,
+      4
+    ],
     "raw": "[\\-]"
+  },
+  "[}]": {
+    "type": "characterClass",
+    "body": [
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 125,
+        "range": [
+          1,
+          2
+        ],
+        "raw": "}"
+      }
+    ],
+    "negative": false,
+    "range": [
+      0,
+      3
+    ],
+    "raw": "[}]"
+  },
+  "[^}]": {
+    "type": "characterClass",
+    "body": [
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 125,
+        "range": [
+          2,
+          3
+        ],
+        "raw": "}"
+      }
+    ],
+    "negative": true,
+    "range": [
+      0,
+      4
+    ],
+    "raw": "[^}]"
   }
 }

--- a/test/test-data.json
+++ b/test/test-data.json
@@ -37472,5 +37472,46 @@
       2
     ],
     "raw": "a."
+  },
+  "}": {
+    "type": "value",
+    "kind": "symbol",
+    "codePoint": 125,
+    "range": [
+      0,
+      1
+    ],
+    "raw": "}"
+  },
+  "]": {
+    "type": "value",
+    "kind": "symbol",
+    "codePoint": 93,
+    "range": [
+      0,
+      1
+    ],
+    "raw": "]"
+  },
+  "[}]": {
+    "type": "characterClass",
+    "body": [
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 125,
+        "range": [
+          1,
+          2
+        ],
+        "raw": "}"
+      }
+    ],
+    "negative": false,
+    "range": [
+      0,
+      3
+    ],
+    "raw": "[}]"
   }
 }


### PR DESCRIPTION
This is intended to fix #101, see also #100.

Note: I wrote the code to fix the bug, but I was not able to figure out what's the correct way to do here is according to the spec. If someone has a pointer to the relevant chapter in the spec, that would be great.