### PR TITLE
Fixes /[\w-e]/ browser behavior

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -11,7 +11,9 @@ var stringify = function(obj) {
   });
 };
 
-var runTests = function(data, flags, features) {
+var runTests = function(data_path, flags, features) {
+  console.log('Testing:', data_path);
+  data = require(data_path)
   Object.keys(data).forEach(function(regex) {
     var results = data[regex];
     flags || (flags = '');
@@ -33,27 +35,27 @@ var runTests = function(data, flags, features) {
         ':' + JSON.stringify(par) + '\n' + JSON.stringify(results)
       );
     } else {
-      console.log('PASSED TEST: ' + regex);
+      console.log('  PASSED TEST: ' + regex);
     }
   });
 };
 
-runTests(require('./test-data.json'), '');
-runTests(require('./test-data-lookbehind.json'), '', {
+runTests('./test-data.json', '');
+runTests('./test-data-lookbehind.json', '', {
   lookbehind: true
 });
-runTests(require('./test-data-unicode.json'), 'u');
-runTests(require('./test-data-unicode-properties.json'), 'u', {
+runTests('./test-data-unicode.json', 'u');
+runTests('./test-data-unicode-properties.json', 'u', {
   unicodePropertyEscape: true
 });
-runTests(require('./test-data-nonstandard.json'), '');
-runTests(require('./test-data-named-groups.json'), '', {
+runTests('./test-data-nonstandard.json', '');
+runTests('./test-data-named-groups.json', '', {
   namedGroups: true
 });
-runTests(require('./test-data-named-groups-unicode.json'), 'u', {
+runTests('./test-data-named-groups-unicode.json', 'u', {
   namedGroups: true
 });
-runTests(require('./test-data-named-groups-unicode-properties.json'), 'u', {
+runTests('./test-data-named-groups-unicode-properties.json', 'u', {
   namedGroups: true,
   unicodePropertyEscape: true
 });

--- a/test/test-data-unicode.json
+++ b/test/test-data-unicode.json
@@ -985,5 +985,56 @@
       4
     ],
     "raw": "[^}]"
+  },
+  "[\\b-e]": {
+    "type": "characterClass",
+    "body": [
+      {
+        "type": "characterClassRange",
+        "min": {
+          "type": "value",
+          "kind": "singleEscape",
+          "codePoint": 8,
+          "range": [
+            1,
+            3
+          ],
+          "raw": "\\b"
+        },
+        "max": {
+          "type": "value",
+          "kind": "symbol",
+          "codePoint": 101,
+          "range": [
+            4,
+            5
+          ],
+          "raw": "e"
+        },
+        "range": [
+          1,
+          5
+        ],
+        "raw": "\\b-e"
+      }
+    ],
+    "negative": false,
+    "range": [
+      0,
+      6
+    ],
+    "raw": "[\\b-e]"
+  },
+  "[e-\\b]": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "invalid range in character class at position 1: e-\\b\n    [e-\\b]\n     ^",
+    "input": "[e-\\b]"
+  },
+  "[\\w-e]": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "invalid character class at position 5\n    [\\w-e]\n         ^",
+    "input": "[\\w-e]"
   }
 }

--- a/test/test-data-unicode.json
+++ b/test/test-data-unicode.json
@@ -1036,5 +1036,44 @@
     "name": "SyntaxError",
     "message": "invalid character class at position 5\n    [\\w-e]\n         ^",
     "input": "[\\w-e]"
+  },
+  "[\\0-\\b]": {
+    "type": "characterClass",
+    "body": [
+      {
+        "type": "characterClassRange",
+        "min": {
+          "type": "value",
+          "kind": "null",
+          "codePoint": 0,
+          "range": [
+            0,
+            3
+          ],
+          "raw": "[\\0"
+        },
+        "max": {
+          "type": "value",
+          "kind": "singleEscape",
+          "codePoint": 8,
+          "range": [
+            4,
+            6
+          ],
+          "raw": "\\b"
+        },
+        "range": [
+          0,
+          6
+        ],
+        "raw": "[\\0-\\b"
+      }
+    ],
+    "negative": false,
+    "range": [
+      0,
+      7
+    ],
+    "raw": "[\\0-\\b]"
   }
 }

--- a/test/test-data.json
+++ b/test/test-data.json
@@ -37514,37 +37514,36 @@
     ],
     "raw": "[}]"
   },
-  "[\\w-e]": {
+  "[\\b-e]": {
     "type": "characterClass",
     "body": [
       {
-        "type": "characterClassEscape",
-        "value": "w",
+        "type": "characterClassRange",
+        "min": {
+          "type": "value",
+          "kind": "singleEscape",
+          "codePoint": 8,
+          "range": [
+            1,
+            3
+          ],
+          "raw": "\\b"
+        },
+        "max": {
+          "type": "value",
+          "kind": "symbol",
+          "codePoint": 101,
+          "range": [
+            4,
+            5
+          ],
+          "raw": "e"
+        },
         "range": [
           1,
-          3
-        ],
-        "raw": "\\w"
-      },
-      {
-        "type": "value",
-        "kind": "symbol",
-        "codePoint": 45,
-        "range": [
-          3,
-          4
-        ],
-        "raw": "-"
-      },
-      {
-        "type": "value",
-        "kind": "symbol",
-        "codePoint": 101,
-        "range": [
-          4,
           5
         ],
-        "raw": "e"
+        "raw": "\\b-e"
       }
     ],
     "negative": false,
@@ -37552,46 +37551,12 @@
       0,
       6
     ],
-    "raw": "[\\w-e]"
+    "raw": "[\\b-e]"
   },
-  "[e-\\w]": {
-    "type": "characterClass",
-    "body": [
-      {
-        "type": "value",
-        "kind": "symbol",
-        "codePoint": 101,
-        "range": [
-          1,
-          2
-        ],
-        "raw": "e"
-      },
-      {
-        "type": "value",
-        "kind": "symbol",
-        "codePoint": 45,
-        "range": [
-          2,
-          3
-        ],
-        "raw": "-"
-      },
-      {
-        "type": "characterClassEscape",
-        "value": "w",
-        "range": [
-          3,
-          5
-        ],
-        "raw": "\\w"
-      }
-    ],
-    "negative": false,
-    "range": [
-      0,
-      6
-    ],
-    "raw": "[e-\\w]"
+  "[e-\\b]": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "invalid range in character class at position 1: e-\\b\n    [e-\\b]\n     ^",
+    "input": "[e-\\b]"
   }
 }

--- a/test/test-data.json
+++ b/test/test-data.json
@@ -37513,5 +37513,85 @@
       3
     ],
     "raw": "[}]"
+  },
+  "[\\w-e]": {
+    "type": "characterClass",
+    "body": [
+      {
+        "type": "characterClassEscape",
+        "value": "w",
+        "range": [
+          1,
+          3
+        ],
+        "raw": "\\w"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 45,
+        "range": [
+          3,
+          4
+        ],
+        "raw": "-"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 101,
+        "range": [
+          4,
+          5
+        ],
+        "raw": "e"
+      }
+    ],
+    "negative": false,
+    "range": [
+      0,
+      6
+    ],
+    "raw": "[\\w-e]"
+  },
+  "[e-\\w]": {
+    "type": "characterClass",
+    "body": [
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 101,
+        "range": [
+          1,
+          2
+        ],
+        "raw": "e"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 45,
+        "range": [
+          2,
+          3
+        ],
+        "raw": "-"
+      },
+      {
+        "type": "characterClassEscape",
+        "value": "w",
+        "range": [
+          3,
+          5
+        ],
+        "raw": "\\w"
+      }
+    ],
+    "negative": false,
+    "range": [
+      0,
+      6
+    ],
+    "raw": "[e-\\w]"
   }
 }

--- a/test/test-data.json
+++ b/test/test-data.json
@@ -37558,5 +37558,44 @@
     "name": "SyntaxError",
     "message": "invalid range in character class at position 1: e-\\b\n    [e-\\b]\n     ^",
     "input": "[e-\\b]"
+  },
+  "[\\0-\\b]": {
+    "type": "characterClass",
+    "body": [
+      {
+        "type": "characterClassRange",
+        "min": {
+          "type": "value",
+          "kind": "null",
+          "codePoint": 0,
+          "range": [
+            0,
+            3
+          ],
+          "raw": "[\\0"
+        },
+        "max": {
+          "type": "value",
+          "kind": "singleEscape",
+          "codePoint": 8,
+          "range": [
+            4,
+            6
+          ],
+          "raw": "\\b"
+        },
+        "range": [
+          0,
+          6
+        ],
+        "raw": "[\\0-\\b"
+      }
+    ],
+    "negative": false,
+    "range": [
+      0,
+      7
+    ],
+    "raw": "[\\0-\\b]"
   }
 }


### PR DESCRIPTION
This fixes #80. 

I was not able to find a part in the spec about this. The rule I came up with is: If the from or to parts of the class range has no `codePoint`, then assume it's not possible to create a `from` and `to` range. In this case, emit the atoms and dash as separate elements to the parse tree output.

\cc @icefapper 