### PR TITLE
Fixing #105 /{(?<x>)}/

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -494,7 +494,7 @@
 
         // If no unicode flag, then try to parse ExtendedAtom -> ExtendedPatternCharacter.
         //      ExtendedPatternCharacter
-        if (!hasUnicodeFlag && (res = matchReg(/^[^^$\\.*+?()[|]/))) {
+        if (!hasUnicodeFlag && (res = matchReg(/^{/))) {
           atom = createCharacter(res);
         } else {
           bail('Expected atom');

--- a/parser.js
+++ b/parser.js
@@ -483,7 +483,22 @@
 
       var atom = parseAtomAndExtendedAtom();
       if (!atom) {
-        bail('Expected atom');
+        // Check if a quantifier is following. A quantifier without an atom
+        // is an error.
+        pos_backup = pos
+        var quantifier = parseQuantifier() || false;
+        if (quantifier) {
+          pos = pos_backup
+          bail('Expected atom');
+        }
+
+        // If no unicode flag, then try to parse ExtendedAtom -> ExtendedPatternCharacter.
+        //      ExtendedPatternCharacter
+        if (!hasUnicodeFlag && (res = matchReg(/^[^^$\\.*+?()[|]/))) {
+          atom = createCharacter(res);
+        } else {
+          bail('Expected atom');
+        }
       }
       var quantifier = parseQuantifier() || false;
       if (quantifier) {
@@ -632,7 +647,7 @@
         return createCharacter(res);
       }
       else if (!hasUnicodeFlag && (res = matchReg(/^(?:]|})/))) {
-        //      ExtendedPatternCharacter
+        //      ExtendedPatternCharacter, first part. See parseTerm.
         return createCharacter(res);
       }
       else if (match('.')) {

--- a/test/test-data-named-groups.json
+++ b/test/test-data-named-groups.json
@@ -218,5 +218,54 @@
     "name": "SyntaxError",
     "message": "Invalid escape sequence at position 3\n    (?<\\u0000>)\n       ^",
     "input": "(?<\\u0000>)"
+  },
+  "{(?<x>)}": {
+    "type": "alternative",
+    "body": [
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 123,
+        "range": [
+          0,
+          1
+        ],
+        "raw": "{"
+      },
+      {
+        "type": "group",
+        "behavior": "normal",
+        "body": [],
+        "range": [
+          1,
+          7
+        ],
+        "raw": "(?<x>)",
+        "name": {
+          "type": "identifier",
+          "value": "x",
+          "range": [
+            4,
+            5
+          ],
+          "raw": "x"
+        }
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 125,
+        "range": [
+          7,
+          8
+        ],
+        "raw": "}"
+      }
+    ],
+    "range": [
+      0,
+      8
+    ],
+    "raw": "{(?<x>)}"
   }
 }

--- a/test/test-data-unicode.json
+++ b/test/test-data-unicode.json
@@ -1075,5 +1075,11 @@
       7
     ],
     "raw": "[\\0-\\b]"
+  },
+  "{}": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "Expected atom at position 0\n    {}\n    ^",
+    "input": "{}"
   }
 }

--- a/test/test-data.json
+++ b/test/test-data.json
@@ -37597,5 +37597,41 @@
       7
     ],
     "raw": "[\\0-\\b]"
+  },
+  "{1}": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "Expected atom at position 0\n    {1}\n    ^",
+    "input": "{1}"
+  },
+  "{}": {
+    "type": "alternative",
+    "body": [
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 123,
+        "range": [
+          0,
+          1
+        ],
+        "raw": "{"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 125,
+        "range": [
+          1,
+          2
+        ],
+        "raw": "}"
+      }
+    ],
+    "range": [
+      0,
+      2
+    ],
+    "raw": "{}"
   }
 }


### PR DESCRIPTION
This is work in progress. The current change improves parsing of empty brackets like /{}/ but does not yet parse cases like `/{(?<x>)}/` from #105 .