### PR TITLE
Fix escaped dash in non-unicode mode.

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -751,7 +751,7 @@
           return createEscaped('controlLetter', 31, '_', 2);
         }
         //     [+U] -
-        if (match('-') && hasUnicodeFlag) {
+        if (hasUnicodeFlag && match('-')) {
           return createEscaped('singleEscape', 0x002d, '\\-');
         }
       }

--- a/test/test-data.json
+++ b/test/test-data.json
@@ -37654,5 +37654,26 @@
       5
     ],
     "raw": "[\\c_]"
+  },
+  "[\\-]": {
+    "type": "characterClass",
+    "body": [
+      {
+        "type": "value",
+        "kind": "identifier",
+        "codePoint": 45,
+        "range": [
+          1,
+          3
+        ],
+        "raw": "\\-"
+      }
+    ],
+    "negative": false,
+    "range": [
+      0,
+      4
+    ],
+    "raw": "[\\-]"
   }
 }


### PR DESCRIPTION
Doing the match before testing for the unicode flag incremented the position. This caused the matching to fail for the regexp `/[\\-]/`.

Closes #109.