### PR TITLE
Fix start range for matching \\0

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -814,7 +814,7 @@
         match = res[0];
         if (/^0{1,3}$/.test(match)) {
           // If they are all zeros, then only take the first one.
-          return createEscaped('null', 0x0000, '0', match.length + 1);
+          return createEscaped('null', 0x0000, '0', match.length);
         } else {
           return createEscaped('octal', parseInt(match, 8), match, 1);
         }

--- a/test/test-data-unicode.json
+++ b/test/test-data-unicode.json
@@ -1047,10 +1047,10 @@
           "kind": "null",
           "codePoint": 0,
           "range": [
-            0,
+            1,
             3
           ],
-          "raw": "[\\0"
+          "raw": "\\0"
         },
         "max": {
           "type": "value",
@@ -1063,10 +1063,10 @@
           "raw": "\\b"
         },
         "range": [
-          0,
+          1,
           6
         ],
-        "raw": "[\\0-\\b"
+        "raw": "\\0-\\b"
       }
     ],
     "negative": false,

--- a/test/test-data.json
+++ b/test/test-data.json
@@ -21845,10 +21845,10 @@
         "kind": "null",
         "codePoint": 0,
         "range": [
-          0,
+          1,
           5
         ],
-        "raw": "[\\000"
+        "raw": "\\000"
       },
       {
         "type": "value",
@@ -30426,7 +30426,7 @@
     "kind": "null",
     "codePoint": 0,
     "range": [
-      -1,
+      0,
       2
     ],
     "raw": "\\0"
@@ -37569,10 +37569,10 @@
           "kind": "null",
           "codePoint": 0,
           "range": [
-            0,
+            1,
             3
           ],
-          "raw": "[\\0"
+          "raw": "\\0"
         },
         "max": {
           "type": "value",
@@ -37585,10 +37585,10 @@
           "raw": "\\b"
         },
         "range": [
-          0,
+          1,
           6
         ],
-        "raw": "[\\0-\\b"
+        "raw": "\\0-\\b"
       }
     ],
     "negative": false,


### PR DESCRIPTION
This fixes/closes #111 . Turns out there were already some tests that had wrong range in the testsuite.