### PR TITLE
fix: do not create back reference inside ch class

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -893,9 +893,15 @@
       else if (res = matchReg(/^[0-7]{1,3}/)) {
         match = res[0];
         if (/^0{1,3}$/.test(match)) {
+          if (hasUnicodeFlag && match.length > 1) {
+            bail("Invalid decimal escape in unicode mode", null, from, pos);
+          }
           // If they are all zeros, then only take the first one.
           return createEscaped('null', 0x0000, '0', match.length);
         } else {
+          if (hasUnicodeFlag) {
+            bail("Invalid decimal escape in unicode mode", null, from, pos);
+          }
           return createEscaped('octal', parseInt(match, 8), match, 1);
         }
       }

--- a/parser.js
+++ b/parser.js
@@ -805,7 +805,7 @@
 
       var res, from = pos;
 
-      res = parseDecimalEscape() || parseNamedReference();
+      res = parseDecimalEscape(insideCharacterClass) || parseNamedReference();
       if (res) {
         return res;
       }
@@ -841,16 +841,18 @@
     }
 
 
-    function parseDecimalEscape() {
+    function parseDecimalEscape(insideCharacterClass) {
       // DecimalEscape ::
       //      DecimalIntegerLiteral [lookahead ∉ DecimalDigit]
 
-      var res, match;
+      var res, match, from = pos;
 
       if (res = matchReg(/^(?!0)\d+/)) {
         match = res[0];
         var refIdx = parseInt(res[0], 10);
-        if (refIdx <= closedCaptureCounter) {
+        if (hasUnicodeFlag) {
+          bail("Invalid decimal escape in unicode mode", null, from, pos);
+        } else if (refIdx <= closedCaptureCounter && !insideCharacterClass) {
           // If the number is smaller than the normal-groups found so
           // far, then it is a reference...
           return createReference(res[0]);

--- a/parser.js
+++ b/parser.js
@@ -847,12 +847,20 @@
 
       var res, match, from = pos;
 
+      if (hasUnicodeFlag) {
+        if (res = matchReg(/^\d/)) {
+          if (res[0] !== "0" || (res = matchReg(/^\d/)) ) {
+            bail("Invalid decimal escape in unicode mode", null, from, pos);
+          }
+          return createEscaped('null', 0x0000, '0', 1);
+        }
+        return false;
+      }
+
       if (res = matchReg(/^(?!0)\d+/)) {
         match = res[0];
         var refIdx = parseInt(res[0], 10);
-        if (hasUnicodeFlag) {
-          bail("Invalid decimal escape in unicode mode", null, from, pos);
-        } else if (refIdx <= closedCaptureCounter && !insideCharacterClass) {
+        if (refIdx <= closedCaptureCounter && !insideCharacterClass) {
           // If the number is smaller than the normal-groups found so
           // far, then it is a reference...
           return createReference(res[0]);
@@ -893,15 +901,9 @@
       else if (res = matchReg(/^[0-7]{1,3}/)) {
         match = res[0];
         if (/^0{1,3}$/.test(match)) {
-          if (hasUnicodeFlag && match.length > 1) {
-            bail("Invalid decimal escape in unicode mode", null, from, pos);
-          }
           // If they are all zeros, then only take the first one.
           return createEscaped('null', 0x0000, '0', match.length);
         } else {
-          if (hasUnicodeFlag) {
-            bail("Invalid decimal escape in unicode mode", null, from, pos);
-          }
           return createEscaped('octal', parseInt(match, 8), match, 1);
         }
       }

--- a/test/test-data-unicode.json
+++ b/test/test-data-unicode.json
@@ -1100,5 +1100,11 @@
     "name": "SyntaxError",
     "message": "Expected atom at position 0\n    {}\n    ^",
     "input": "{}"
+  },
+  "([\\1])": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "Invalid decimal escape in unicode mode at position 3\n    ([\\1])\n       ^",
+    "input": "([\\1])"
   }
 }

--- a/test/test-data-unicode.json
+++ b/test/test-data-unicode.json
@@ -1106,5 +1106,39 @@
     "name": "SyntaxError",
     "message": "Invalid decimal escape in unicode mode at position 3\n    ([\\1])\n       ^",
     "input": "([\\1])"
+  },
+  "\\10": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "Invalid decimal escape in unicode mode at position 1\n    \\10\n     ^",
+    "input": "\\10"
+  },
+  "\\01": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "Invalid decimal escape in unicode mode at position 1\n    \\01\n     ^",
+    "input": "\\01"
+  },
+  "\\00": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "Invalid decimal escape in unicode mode at position 1\n    \\00\n     ^",
+    "input": "\\00"
+  },
+  "\\8": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "Invalid decimal escape in unicode mode at position 1\n    \\8\n     ^",
+    "input": "\\8"
+  },
+  "\\0": {
+    "type": "value",
+    "kind": "null",
+    "codePoint": 0,
+    "range": [
+      0,
+      2
+    ],
+    "raw": "\\0"
   }
 }

--- a/test/test-data.json
+++ b/test/test-data.json
@@ -38021,5 +38021,38 @@
       4
     ],
     "raw": "[\\-]"
+  },
+  "([\\1])": {
+    "type": "group",
+    "behavior": "normal",
+    "body": [
+      {
+        "type": "characterClass",
+        "kind": "union",
+        "body": [
+          {
+            "type": "value",
+            "kind": "octal",
+            "codePoint": 1,
+            "range": [
+              2,
+              4
+            ],
+            "raw": "\\1"
+          }
+        ],
+        "negative": false,
+        "range": [
+          1,
+          5
+        ],
+        "raw": "[\\1]"
+      }
+    ],
+    "range": [
+      0,
+      6
+    ],
+    "raw": "([\\1])"
   }
 }


### PR DESCRIPTION
Fixes #114.

Per spec, the `CharacterRanges` does not cover `AtomEscape`, so `\NonZeroDecimalDigit` must be parsed as an value.

When Unicode mode is on, the only valid decimal escape is `\0`.