### PR TITLE
bail if quantifier iterations out of safe integer range

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -690,7 +690,7 @@
       }
 
       if ((min && !Number.isSafeInteger(min)) || (max && !Number.isSafeInteger(max))) {
-        bail("iterations out of safe range in quantifier", "", from, pos);
+        bail("iterations outside JS safe integer range in quantifier", "", from, pos);
       }
 
       if (quantifier) {

--- a/parser.js
+++ b/parser.js
@@ -689,7 +689,7 @@
         quantifier = createQuantifier(min, max, res.range[0], res.range[1]);
       }
 
-      if ((min && !Number.isSafeInteger(min)) || max && !Number.isSafeInteger(max)) {
+      if ((min && !Number.isSafeInteger(min)) || (max && !Number.isSafeInteger(max))) {
         bail("iterations out of safe range in quantifier", "", from, pos);
       }
 

--- a/parser.js
+++ b/parser.js
@@ -689,6 +689,10 @@
         quantifier = createQuantifier(min, max, res.range[0], res.range[1]);
       }
 
+      if ((min && !Number.isSafeInteger(min)) || max && !Number.isSafeInteger(max)) {
+        bail("iterations out of safe range in quantifier", "", from, pos);
+      }
+
       if (quantifier) {
         if (match('?')) {
           quantifier.greedy = false;

--- a/test/test-data.json
+++ b/test/test-data.json
@@ -37533,19 +37533,19 @@
   "x{9999999999999999999}": {
     "type": "error",
     "name": "SyntaxError",
-    "message": "iterations out of safe range in quantifier at position 1\n    x{9999999999999999999}\n     ^",
+    "message": "iterations outside JS safe integer range in quantifier at position 1\n    x{9999999999999999999}\n     ^",
     "input": "x{9999999999999999999}"
   },
   "x{0,9999999999999999999}": {
     "type": "error",
     "name": "SyntaxError",
-    "message": "iterations out of safe range in quantifier at position 1\n    x{0,9999999999999999999}\n     ^",
+    "message": "iterations outside JS safe integer range in quantifier at position 1\n    x{0,9999999999999999999}\n     ^",
     "input": "x{0,9999999999999999999}"
   },
   "x{9999999999999999999,9999999999999999999}": {
     "type": "error",
     "name": "SyntaxError",
-    "message": "iterations out of safe range in quantifier at position 1\n    x{9999999999999999999,9999999999999999999}\n     ^",
+    "message": "iterations outside JS safe integer range in quantifier at position 1\n    x{9999999999999999999,9999999999999999999}\n     ^",
     "input": "x{9999999999999999999,9999999999999999999}"
   },
   "z": {

--- a/test/test-data.json
+++ b/test/test-data.json
@@ -37530,6 +37530,24 @@
     "message": "Expected atom at position 4\n    x{1}{1,}\n        ^",
     "input": "x{1}{1,}"
   },
+  "x{9999999999999999999}": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "iterations out of safe range in quantifier at position 1\n    x{9999999999999999999}\n     ^",
+    "input": "x{9999999999999999999}"
+  },
+  "x{0,9999999999999999999}": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "iterations out of safe range in quantifier at position 1\n    x{0,9999999999999999999}\n     ^",
+    "input": "x{0,9999999999999999999}"
+  },
+  "x{9999999999999999999,9999999999999999999}": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "iterations out of safe range in quantifier at position 1\n    x{9999999999999999999,9999999999999999999}\n     ^",
+    "input": "x{9999999999999999999,9999999999999999999}"
+  },
   "z": {
     "type": "value",
     "kind": "symbol",


### PR DESCRIPTION
Currently it's possible to get the wrong result if the number of iterations is outside the JS safe range. This makes it bail instead.

An other approach could be adding string versions of the min and max `minString`/`maxString` (?) and allowing `min` and `max` to be `null` when outside the range JS can represent? This feels better in that it doesn't cause an error on regex that would be valid but that JS can't represent.

Not sure if this should be considered a breaking change. Depends if getting a number close the actual number, but wrong, should be classed as a bug or not 🤷 