### PR TITLE
include parser.d.ts in the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "bin/",
     "LICENSE.BSD",
     "parser.js",
+    "parser.d.ts",
     "README.md"
   ],
   "dependencies": {


### PR DESCRIPTION
Currently the types are missing