### PR TITLE
fix reference type when named groups enabled

### DIFF
--- a/parser.d.ts
+++ b/parser.d.ts
@@ -100,9 +100,9 @@ export type CharacterClass<F extends Features = {}> = Base<"characterClass"> & {
 };
 
 export type ModifierFlags = {
-  enabling: string,
-  disabling: string
-}
+  enabling: string;
+  disabling: string;
+};
 
 export type NonCapturingGroup<F extends Features = {}> = Base<"group"> &
   (
@@ -128,7 +128,6 @@ export type NonCapturingGroup<F extends Features = {}> = Base<"group"> &
       >)
   );
 
-
 export type CapturingGroup<F extends Features = {}> = Base<"group"> & {
   behavior: "normal";
   body: RootNode<F>[];
@@ -151,7 +150,7 @@ export type Quantifier<F extends Features = {}> = Base<"quantifier"> & {
   greedy: boolean;
   max?: number;
   min: number;
-  symbol?: '?' | '*' | '+';
+  symbol?: "?" | "*" | "+";
 };
 
 export type Disjunction<F extends Features = {}> = Base<"disjunction"> & {
@@ -172,7 +171,7 @@ export type IndexReference = Base<"reference"> & {
 
 export type Reference<F extends Features = {}> = _If<
   F["namedGroups"],
-  NamedReference,
+  IndexReference | NamedReference,
   IndexReference
 >;
 

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,4 +1,10 @@
-import { AstNodeType, Identifier, ModifierFlags, parse, RootNode } from "../parser";
+import {
+  AstNodeType,
+  Identifier,
+  ModifierFlags,
+  parse,
+  RootNode,
+} from "../parser";
 
 function assert<T>(input: T): void {}
 
@@ -58,7 +64,8 @@ if (
 
 if (nodeWithNamedGroups.type === "reference") {
   // namedGroups = true
-  assert<Identifier>(nodeWithNamedGroups.name);
+  assert<number | undefined>(nodeWithNamedGroups.matchIndex);
+  assert<Identifier | undefined>(nodeWithNamedGroups.name);
 }
 
 let nodeWithMaybeNamedGroups = parse("", "", {


### PR DESCRIPTION
The type previously did not allow the reference to be an index type reference if `namedGroups` was enabled