### PR TITLE
Fix inline modifiers inside lookarounds

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -780,7 +780,7 @@
         group.name = name;
         return group;
       }
-      else if (features.modifiers && str.indexOf("(?") == pos && str[pos + 2] != ":") {
+      else if (features.modifiers && str.indexOf("(?", pos) === pos && str[pos + 2] != ":") {
         return parseModifiersGroup();
       }
       else {


### PR DESCRIPTION
Inside `parseAtomAndExtendedAtom`, `(?` used to be searched from the start of the string, rather than from the current position. So, trying to parse an expression containing nested lookarounds and inline modifiers (e.g., `/(?<=(?i:un))parse(?=(?i:able))/`) threw an error.

Didn't quite understand how the tests work, so didn't write one, sorry.