### PR TITLE
disallow quantifiable anchors in unicode mode

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -598,6 +598,21 @@
 
       quantifier = parseQuantifier() || false;
       if (quantifier) {
+        var type = anchorOrAtom.type, behavior = anchorOrAtom.behavior;
+        if (
+          type === "group" &&
+          (behavior === "negativeLookbehind" ||
+            behavior === "lookbehind" ||
+            (isUnicodeMode &&
+              (behavior === "negativeLookahead" || behavior === "lookahead")))
+        ) {
+          bail(
+            "Invalid quantifier",
+            "",
+            quantifier.range[0],
+            quantifier.range[1]
+          );
+        }
         quantifier.body = flattenBody(anchorOrAtom);
         // The quantifier contains the atom. Therefore, the beginning of the
         // quantifier range is given by the beginning of the atom.

--- a/test/test-data-lookbehind.json
+++ b/test/test-data-lookbehind.json
@@ -359,5 +359,17 @@
     "name": "SyntaxError",
     "message": "atomEscape at position 1\n    \\k\n     ^",
     "input": "\\k"
+  },
+  "(?<=.){2,3}": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "Invalid quantifier at position 6\n    (?<=.){2,3}\n          ^",
+    "input": "(?<=.){2,3}"
+  },
+  "(?<!.){2,3}": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "Invalid quantifier at position 6\n    (?<!.){2,3}\n          ^",
+    "input": "(?<!.){2,3}"
   }
 }

--- a/test/test-data-unicode-set.json
+++ b/test/test-data-unicode-set.json
@@ -1561,5 +1561,17 @@
       21
     ],
     "raw": "[\\u{14630}-\\u{14633}]"
+  },
+  ".(?=.){2,3}": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "Invalid quantifier at position 6\n    .(?=.){2,3}\n          ^",
+    "input": ".(?=.){2,3}"
+  },
+  ".(?!.){2,3}": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "Invalid quantifier at position 6\n    .(?!.){2,3}\n          ^",
+    "input": ".(?!.){2,3}"
   }
 }

--- a/test/test-data-unicode.json
+++ b/test/test-data-unicode.json
@@ -1228,5 +1228,17 @@
     "name": "SyntaxError",
     "message": "Invalid decimal escape in unicode mode at position 1\n    \\2(.)\n     ^",
     "input": "\\2(.)"
+  },
+  ".(?=.){2,3}": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "Invalid quantifier at position 6\n    .(?=.){2,3}\n          ^",
+    "input": ".(?=.){2,3}"
+  },
+  ".(?!.){2,3}": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "Invalid quantifier at position 6\n    .(?!.){2,3}\n          ^",
+    "input": ".(?!.){2,3}"
   }
 }

--- a/test/test-data.json
+++ b/test/test-data.json
@@ -38524,5 +38524,107 @@
       6
     ],
     "raw": "(?=a)?"
+  },
+  ".(?=.){2,3}": {
+    "type": "alternative",
+    "body": [
+      {
+        "type": "dot",
+        "range": [
+          0,
+          1
+        ],
+        "raw": "."
+      },
+      {
+        "type": "quantifier",
+        "min": 2,
+        "max": 3,
+        "greedy": true,
+        "body": [
+          {
+            "type": "group",
+            "behavior": "lookahead",
+            "body": [
+              {
+                "type": "dot",
+                "range": [
+                  4,
+                  5
+                ],
+                "raw": "."
+              }
+            ],
+            "range": [
+              1,
+              6
+            ],
+            "raw": "(?=.)"
+          }
+        ],
+        "symbol": null,
+        "range": [
+          1,
+          11
+        ],
+        "raw": "(?=.){2,3}"
+      }
+    ],
+    "range": [
+      0,
+      11
+    ],
+    "raw": ".(?=.){2,3}"
+  },
+  ".(?!.){2,3}": {
+    "type": "alternative",
+    "body": [
+      {
+        "type": "dot",
+        "range": [
+          0,
+          1
+        ],
+        "raw": "."
+      },
+      {
+        "type": "quantifier",
+        "min": 2,
+        "max": 3,
+        "greedy": true,
+        "body": [
+          {
+            "type": "group",
+            "behavior": "negativeLookahead",
+            "body": [
+              {
+                "type": "dot",
+                "range": [
+                  4,
+                  5
+                ],
+                "raw": "."
+              }
+            ],
+            "range": [
+              1,
+              6
+            ],
+            "raw": "(?!.)"
+          }
+        ],
+        "symbol": null,
+        "range": [
+          1,
+          11
+        ],
+        "raw": "(?!.){2,3}"
+      }
+    ],
+    "range": [
+      0,
+      11
+    ],
+    "raw": ".(?!.){2,3}"
   }
 }


### PR DESCRIPTION
Fixes #134 

/cc @mathiasbynens @nicolo-ribaudo 

It seems to me that the spec does not disallow quantified +/- lookahead in unicode sets mode, as is in unicode mode:

https://tc39.es/ecma262/#prod-annexB-Assertion

But both JSC and V8 disallow such productions. It seems to me an oversight in the spec.