### PR TITLE
upgrade jsesc dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "README.md"
   ],
   "dependencies": {
-    "jsesc": "~0.5.0"
+    "jsesc": "~3.0.2"
   },
   "devDependencies": {
     "eslint": "^9.10.0",


### PR DESCRIPTION
The current version of `jsesc` has an incorrect `license` field in the `package.json` that was corrected in a later release so would be nice to update to the newer version.