### PR TITLE
Improve regexp invalid modifiers errors

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -216,9 +216,15 @@
 // --------------------------------------------------------------
 //
 // Atom ::
-//      ( ? RegularExpressionFlags : Disjunction )
-//      ( ? RegularExpressionFlags - RegularExpressionFlags : Disjunction )
+//      ( ? RegularExpressionModifiers : Disjunction )
+//      ( ? RegularExpressionModifiers - RegularExpressionModifiers : Disjunction )
 //
+// RegularExpressionModifiers:
+//      [empty]
+//      RegularExpressionModifiers RegularExpressionModifier
+//
+// RegularExpressionModifier:
+//      one of i m s
 
 "use strict";
 (function() {
@@ -747,8 +753,8 @@
       //      \ AtomEscape
       //      CharacterClass
       //      ( GroupSpecifier Disjunction )
-      //      ( ? RegularExpressionFlags : Disjunction )
-      //      ( ? RegularExpressionFlags - RegularExpressionFlags : Disjunction )
+      //      ( ? RegularExpressionModifiers : Disjunction )
+      //      ( ? RegularExpressionModifiers - RegularExpressionModifiers : Disjunction )
       // ExtendedAtom ::
       //      ExtendedPatternCharacter
       // ExtendedPatternCharacter ::

--- a/parser.js
+++ b/parser.js
@@ -827,26 +827,26 @@
       var from = pos;
       incr(2);
 
-      var enablingFlags = matchReg(/^[sim]+/);
-      var disablingFlags;
-      if(match("-")){
-        disablingFlags = matchReg(/^[sim]+/);
-        if (!disablingFlags) {
-          bail('Invalid flags for modifiers group');
-        }
-      } else if(!enablingFlags){
+      var enablingFlags = matchReg(/^([sim]*)([:-])/);
+      if(!enablingFlags){
         bail('Invalid flags for modifiers group');
       }
 
-      enablingFlags = enablingFlags ? enablingFlags[0] : "";
-      disablingFlags = disablingFlags ? disablingFlags[0] : "";
+      var disablingFlags;
+      if(enablingFlags[2] === "-") {
+        disablingFlags = matchReg(/^([sim]+):/);
+        if (!disablingFlags) {
+          bail('Invalid flags for modifiers group');
+        }
+      }
+
+      enablingFlags = enablingFlags[1];
+      disablingFlags = disablingFlags ? disablingFlags[1] : "";
 
       var flags = enablingFlags + disablingFlags;
       if(flags.length > 3 || hasDupChar(flags)) {
-        bail('flags cannot be duplicated for modifiers group');
+        bail('flags cannot be duplicated for modifiers group', '', pos - 1);
       }
-
-      skip(":");
 
       var modifiersGroup = finishGroup("ignore", from);
 

--- a/parser.js
+++ b/parser.js
@@ -827,25 +827,27 @@
       var from = pos;
       incr(2);
 
-      var enablingFlags = matchReg(/^([sim]*)([:-])/);
-      if(!enablingFlags){
-        bail('Invalid flags for modifiers group');
-      }
-
+      var enablingFlags = matchReg(/^[sim]+/);
       var disablingFlags;
-      if(enablingFlags[2] === "-") {
-        disablingFlags = matchReg(/^([sim]+):/);
+      if(match("-")){
+        disablingFlags = matchReg(/^[sim]+/);
         if (!disablingFlags) {
           bail('Invalid flags for modifiers group');
         }
+      } else if(!enablingFlags){
+        bail('Invalid flags for modifiers group');
       }
 
-      enablingFlags = enablingFlags[1];
-      disablingFlags = disablingFlags ? disablingFlags[1] : "";
+      enablingFlags = enablingFlags ? enablingFlags[0] : "";
+      disablingFlags = disablingFlags ? disablingFlags[0] : "";
 
       var flags = enablingFlags + disablingFlags;
       if(flags.length > 3 || hasDupChar(flags)) {
-        bail('flags cannot be duplicated for modifiers group', '', pos - 1);
+        bail('flags cannot be duplicated for modifiers group');
+      }
+
+      if(!match(":")) {
+        bail('Invalid flags for modifiers group');
       }
 
       var modifiersGroup = finishGroup("ignore", from);

--- a/test/test-data-modifiers-group.json
+++ b/test/test-data-modifiers-group.json
@@ -510,5 +510,29 @@
     "name": "SyntaxError",
     "message": "Invalid flags for modifiers group at position 9\n    ^[a-z](?-:[a-z])$\n             ^",
     "input": "^[a-z](?-:[a-z])$"
+  },
+  "^[a-z](?ui:[a-z])$": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "Invalid flags for modifiers group at position 8\n    ^[a-z](?ui:[a-z])$\n            ^",
+    "input": "^[a-z](?ui:[a-z])$"
+  },
+  "^[a-z](?-ui:[a-z])$": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "Invalid flags for modifiers group at position 9\n    ^[a-z](?-ui:[a-z])$\n             ^",
+    "input": "^[a-z](?-ui:[a-z])$"
+  },
+  "^[a-z](?iu:[a-z])$": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "Invalid flags for modifiers group at position 8\n    ^[a-z](?iu:[a-z])$\n            ^",
+    "input": "^[a-z](?iu:[a-z])$"
+  },
+  "^[a-z](?-iu:[a-z])$": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "Invalid flags for modifiers group at position 9\n    ^[a-z](?-iu:[a-z])$\n             ^",
+    "input": "^[a-z](?-iu:[a-z])$"
   }
 }

--- a/test/test-data-modifiers-group.json
+++ b/test/test-data-modifiers-group.json
@@ -526,13 +526,13 @@
   "^[a-z](?iu:[a-z])$": {
     "type": "error",
     "name": "SyntaxError",
-    "message": "Invalid flags for modifiers group at position 8\n    ^[a-z](?iu:[a-z])$\n            ^",
+    "message": "Invalid flags for modifiers group at position 9\n    ^[a-z](?iu:[a-z])$\n             ^",
     "input": "^[a-z](?iu:[a-z])$"
   },
   "^[a-z](?-iu:[a-z])$": {
     "type": "error",
     "name": "SyntaxError",
-    "message": "Invalid flags for modifiers group at position 9\n    ^[a-z](?-iu:[a-z])$\n             ^",
+    "message": "Invalid flags for modifiers group at position 10\n    ^[a-z](?-iu:[a-z])$\n              ^",
     "input": "^[a-z](?-iu:[a-z])$"
   }
 }


### PR DESCRIPTION
Currently we generate different errors for two equivalent invalid expressions:

```
Invalid flags for modifiers group at position 8
    ^[a-z](?ui:[a-z])$
            ^
```

```
character at position 9: :
    ^[a-z](?iu:[a-z])$
             ^
```

In this PR we improve the parsing logic so that the latter case now throws the same error as the former. We also aligned the production names to the latest draft.