### PR TITLE
fix: allow empty disabling flags

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -829,7 +829,7 @@
 
       var enablingFlags = matchReg(/^[sim]+/);
       var disablingFlags;
-      if(match("-")){
+      if(match("-") && lookahead() !== ":"){
         disablingFlags = matchReg(/^[sim]+/);
         if (!disablingFlags) {
           bail('Invalid flags for modifiers group');

--- a/test/test-data-modifiers-group.json
+++ b/test/test-data-modifiers-group.json
@@ -487,6 +487,129 @@
     ],
     "raw": "^[a-z](?:[a-z])$"
   },
+  "^[a-z](?i-:[a-z])$": {
+    "type": "alternative",
+    "body": [
+      {
+        "type": "anchor",
+        "kind": "start",
+        "range": [
+          0,
+          1
+        ],
+        "raw": "^"
+      },
+      {
+        "type": "characterClass",
+        "kind": "union",
+        "body": [
+          {
+            "type": "characterClassRange",
+            "min": {
+              "type": "value",
+              "kind": "symbol",
+              "codePoint": 97,
+              "range": [
+                2,
+                3
+              ],
+              "raw": "a"
+            },
+            "max": {
+              "type": "value",
+              "kind": "symbol",
+              "codePoint": 122,
+              "range": [
+                4,
+                5
+              ],
+              "raw": "z"
+            },
+            "range": [
+              2,
+              5
+            ],
+            "raw": "a-z"
+          }
+        ],
+        "negative": false,
+        "range": [
+          1,
+          6
+        ],
+        "raw": "[a-z]"
+      },
+      {
+        "type": "group",
+        "behavior": "ignore",
+        "body": [
+          {
+            "type": "characterClass",
+            "kind": "union",
+            "body": [
+              {
+                "type": "characterClassRange",
+                "min": {
+                  "type": "value",
+                  "kind": "symbol",
+                  "codePoint": 97,
+                  "range": [
+                    12,
+                    13
+                  ],
+                  "raw": "a"
+                },
+                "max": {
+                  "type": "value",
+                  "kind": "symbol",
+                  "codePoint": 122,
+                  "range": [
+                    14,
+                    15
+                  ],
+                  "raw": "z"
+                },
+                "range": [
+                  12,
+                  15
+                ],
+                "raw": "a-z"
+              }
+            ],
+            "negative": false,
+            "range": [
+              11,
+              16
+            ],
+            "raw": "[a-z]"
+          }
+        ],
+        "range": [
+          6,
+          17
+        ],
+        "raw": "(?i-:[a-z])",
+        "modifierFlags": {
+          "enabling": "i",
+          "disabling": ""
+        }
+      },
+      {
+        "type": "anchor",
+        "kind": "end",
+        "range": [
+          17,
+          18
+        ],
+        "raw": "$"
+      }
+    ],
+    "range": [
+      0,
+      18
+    ],
+    "raw": "^[a-z](?i-:[a-z])$"
+  },
   "^[a-z](?imi:[a-z])$": {
     "type": "error",
     "name": "SyntaxError",


### PR DESCRIPTION
The propose to update the spec was withdrawn: https://github.com/rbuckton/ecma262/pull/12. So we have to follow the spec and allow empty disabling modifiers after `-`.