### PR TITLE
fix: unicode escape sequence within identifier is always in unicode mode

### DIFF
--- a/test/test-data-named-groups.json
+++ b/test/test-data-named-groups.json
@@ -164,7 +164,7 @@
   "(?<\\u{41})": {
     "type": "error",
     "name": "SyntaxError",
-    "message": "Invalid escape sequence at position 3\n    (?<\\u{41})\n       ^",
+    "message": "character at position 9: >\n    (?<\\u{41})\n             ^",
     "input": "(?<\\u{41})"
   },
   "(?<\\u0041bc\\u0041>)\\k<\\u0041bc\\u0041>": {
@@ -218,6 +218,434 @@
     "name": "SyntaxError",
     "message": "Invalid escape sequence at position 3\n    (?<\\u0000>)\n       ^",
     "input": "(?<\\u0000>)"
+  },
+  "(?<\\u{10000}>b008-A)\\k<\\u{10000}>": {
+    "type": "alternative",
+    "body": [
+      {
+        "type": "group",
+        "behavior": "normal",
+        "body": [
+          {
+            "type": "value",
+            "kind": "symbol",
+            "codePoint": 98,
+            "range": [
+              13,
+              14
+            ],
+            "raw": "b"
+          },
+          {
+            "type": "value",
+            "kind": "symbol",
+            "codePoint": 48,
+            "range": [
+              14,
+              15
+            ],
+            "raw": "0"
+          },
+          {
+            "type": "value",
+            "kind": "symbol",
+            "codePoint": 48,
+            "range": [
+              15,
+              16
+            ],
+            "raw": "0"
+          },
+          {
+            "type": "value",
+            "kind": "symbol",
+            "codePoint": 56,
+            "range": [
+              16,
+              17
+            ],
+            "raw": "8"
+          },
+          {
+            "type": "value",
+            "kind": "symbol",
+            "codePoint": 45,
+            "range": [
+              17,
+              18
+            ],
+            "raw": "-"
+          },
+          {
+            "type": "value",
+            "kind": "symbol",
+            "codePoint": 65,
+            "range": [
+              18,
+              19
+            ],
+            "raw": "A"
+          }
+        ],
+        "range": [
+          0,
+          20
+        ],
+        "raw": "(?<\\u{10000}>b008-A)",
+        "name": {
+          "type": "identifier",
+          "value": "\uD800\uDC00",
+          "range": [
+            3,
+            12
+          ],
+          "raw": "\\u{10000}"
+        }
+      },
+      {
+        "type": "reference",
+        "name": {
+          "type": "identifier",
+          "value": "\uD800\uDC00",
+          "range": [
+            23,
+            32
+          ],
+          "raw": "\\u{10000}"
+        },
+        "range": [
+          20,
+          33
+        ],
+        "raw": "\\k<\\u{10000}>"
+      }
+    ],
+    "range": [
+      0,
+      33
+    ],
+    "raw": "(?<\\u{10000}>b008-A)\\k<\\u{10000}>"
+  },
+  "(?<A\\u{10000}>b008-A)\\k<A\\u{10000}>": {
+    "type": "alternative",
+    "body": [
+      {
+        "type": "group",
+        "behavior": "normal",
+        "body": [
+          {
+            "type": "value",
+            "kind": "symbol",
+            "codePoint": 98,
+            "range": [
+              14,
+              15
+            ],
+            "raw": "b"
+          },
+          {
+            "type": "value",
+            "kind": "symbol",
+            "codePoint": 48,
+            "range": [
+              15,
+              16
+            ],
+            "raw": "0"
+          },
+          {
+            "type": "value",
+            "kind": "symbol",
+            "codePoint": 48,
+            "range": [
+              16,
+              17
+            ],
+            "raw": "0"
+          },
+          {
+            "type": "value",
+            "kind": "symbol",
+            "codePoint": 56,
+            "range": [
+              17,
+              18
+            ],
+            "raw": "8"
+          },
+          {
+            "type": "value",
+            "kind": "symbol",
+            "codePoint": 45,
+            "range": [
+              18,
+              19
+            ],
+            "raw": "-"
+          },
+          {
+            "type": "value",
+            "kind": "symbol",
+            "codePoint": 65,
+            "range": [
+              19,
+              20
+            ],
+            "raw": "A"
+          }
+        ],
+        "range": [
+          0,
+          21
+        ],
+        "raw": "(?<A\\u{10000}>b008-A)",
+        "name": {
+          "type": "identifier",
+          "value": "A\uD800\uDC00",
+          "range": [
+            3,
+            13
+          ],
+          "raw": "A\\u{10000}"
+        }
+      },
+      {
+        "type": "reference",
+        "name": {
+          "type": "identifier",
+          "value": "A\uD800\uDC00",
+          "range": [
+            24,
+            34
+          ],
+          "raw": "A\\u{10000}"
+        },
+        "range": [
+          21,
+          35
+        ],
+        "raw": "\\k<A\\u{10000}>"
+      }
+    ],
+    "range": [
+      0,
+      35
+    ],
+    "raw": "(?<A\\u{10000}>b008-A)\\k<A\\u{10000}>"
+  },
+  "(?<\\ud800\\udc00>b008-A)\\k<\\ud800\\udc00>": {
+    "type": "alternative",
+    "body": [
+      {
+        "type": "group",
+        "behavior": "normal",
+        "body": [
+          {
+            "type": "value",
+            "kind": "symbol",
+            "codePoint": 98,
+            "range": [
+              16,
+              17
+            ],
+            "raw": "b"
+          },
+          {
+            "type": "value",
+            "kind": "symbol",
+            "codePoint": 48,
+            "range": [
+              17,
+              18
+            ],
+            "raw": "0"
+          },
+          {
+            "type": "value",
+            "kind": "symbol",
+            "codePoint": 48,
+            "range": [
+              18,
+              19
+            ],
+            "raw": "0"
+          },
+          {
+            "type": "value",
+            "kind": "symbol",
+            "codePoint": 56,
+            "range": [
+              19,
+              20
+            ],
+            "raw": "8"
+          },
+          {
+            "type": "value",
+            "kind": "symbol",
+            "codePoint": 45,
+            "range": [
+              20,
+              21
+            ],
+            "raw": "-"
+          },
+          {
+            "type": "value",
+            "kind": "symbol",
+            "codePoint": 65,
+            "range": [
+              21,
+              22
+            ],
+            "raw": "A"
+          }
+        ],
+        "range": [
+          0,
+          23
+        ],
+        "raw": "(?<\\ud800\\udc00>b008-A)",
+        "name": {
+          "type": "identifier",
+          "value": "\uD800\uDC00",
+          "range": [
+            3,
+            15
+          ],
+          "raw": "\\ud800\\udc00"
+        }
+      },
+      {
+        "type": "reference",
+        "name": {
+          "type": "identifier",
+          "value": "\uD800\uDC00",
+          "range": [
+            26,
+            38
+          ],
+          "raw": "\\ud800\\udc00"
+        },
+        "range": [
+          23,
+          39
+        ],
+        "raw": "\\k<\\ud800\\udc00>"
+      }
+    ],
+    "range": [
+      0,
+      39
+    ],
+    "raw": "(?<\\ud800\\udc00>b008-A)\\k<\\ud800\\udc00>"
+  },
+  "(?<A\\ud800\\udc00>b008-A)\\k<A\\ud800\\udc00>": {
+    "type": "alternative",
+    "body": [
+      {
+        "type": "group",
+        "behavior": "normal",
+        "body": [
+          {
+            "type": "value",
+            "kind": "symbol",
+            "codePoint": 98,
+            "range": [
+              17,
+              18
+            ],
+            "raw": "b"
+          },
+          {
+            "type": "value",
+            "kind": "symbol",
+            "codePoint": 48,
+            "range": [
+              18,
+              19
+            ],
+            "raw": "0"
+          },
+          {
+            "type": "value",
+            "kind": "symbol",
+            "codePoint": 48,
+            "range": [
+              19,
+              20
+            ],
+            "raw": "0"
+          },
+          {
+            "type": "value",
+            "kind": "symbol",
+            "codePoint": 56,
+            "range": [
+              20,
+              21
+            ],
+            "raw": "8"
+          },
+          {
+            "type": "value",
+            "kind": "symbol",
+            "codePoint": 45,
+            "range": [
+              21,
+              22
+            ],
+            "raw": "-"
+          },
+          {
+            "type": "value",
+            "kind": "symbol",
+            "codePoint": 65,
+            "range": [
+              22,
+              23
+            ],
+            "raw": "A"
+          }
+        ],
+        "range": [
+          0,
+          24
+        ],
+        "raw": "(?<A\\ud800\\udc00>b008-A)",
+        "name": {
+          "type": "identifier",
+          "value": "A\uD800\uDC00",
+          "range": [
+            3,
+            16
+          ],
+          "raw": "A\\ud800\\udc00"
+        }
+      },
+      {
+        "type": "reference",
+        "name": {
+          "type": "identifier",
+          "value": "A\uD800\uDC00",
+          "range": [
+            27,
+            40
+          ],
+          "raw": "A\\ud800\\udc00"
+        },
+        "range": [
+          24,
+          41
+        ],
+        "raw": "\\k<A\\ud800\\udc00>"
+      }
+    ],
+    "range": [
+      0,
+      41
+    ],
+    "raw": "(?<A\\ud800\\udc00>b008-A)\\k<A\\ud800\\udc00>"
   },
   "{(?<x>)}": {
     "type": "alternative",


### PR DESCRIPTION
Context: I pulled the test suites of https://github.com/eslint-community/regexpp and tested regjsparser against them. I will open more PR in the future.