### PR TITLE
fix: only ±lookbehind is quantifiable in annexB

### DIFF
--- a/test/test-data-unicode-set.json
+++ b/test/test-data-unicode-set.json
@@ -1499,13 +1499,13 @@
   ".(?=.){2,3}": {
     "type": "error",
     "name": "SyntaxError",
-    "message": "Invalid quantifier at position 6\n    .(?=.){2,3}\n          ^",
+    "message": "Expected atom at position 6\n    .(?=.){2,3}\n          ^",
     "input": ".(?=.){2,3}"
   },
   ".(?!.){2,3}": {
     "type": "error",
     "name": "SyntaxError",
-    "message": "Invalid quantifier at position 6\n    .(?!.){2,3}\n          ^",
+    "message": "Expected atom at position 6\n    .(?!.){2,3}\n          ^",
     "input": ".(?!.){2,3}"
   },
   "[\\__]": {

--- a/test/test-data-unicode.json
+++ b/test/test-data-unicode.json
@@ -1232,13 +1232,13 @@
   ".(?=.){2,3}": {
     "type": "error",
     "name": "SyntaxError",
-    "message": "Invalid quantifier at position 6\n    .(?=.){2,3}\n          ^",
+    "message": "Expected atom at position 6\n    .(?=.){2,3}\n          ^",
     "input": ".(?=.){2,3}"
   },
   ".(?!.){2,3}": {
     "type": "error",
     "name": "SyntaxError",
-    "message": "Invalid quantifier at position 6\n    .(?!.){2,3}\n          ^",
+    "message": "Expected atom at position 6\n    .(?!.){2,3}\n          ^",
     "input": ".(?!.){2,3}"
   },
   "[&&]": {
@@ -1848,5 +1848,29 @@
       4
     ],
     "raw": "[~~]"
+  },
+  "^*": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "Expected atom at position 1\n    ^*\n     ^",
+    "input": "^*"
+  },
+  "$+": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "Expected atom at position 1\n    $+\n     ^",
+    "input": "$+"
+  },
+  "\\b?": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "Expected atom at position 2\n    \\b?\n      ^",
+    "input": "\\b?"
+  },
+  "\\B{1}": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "Expected atom at position 2\n    \\B{1}\n      ^",
+    "input": "\\B{1}"
   }
 }

--- a/test/test-data.json
+++ b/test/test-data.json
@@ -38626,5 +38626,29 @@
       11
     ],
     "raw": ".(?!.){2,3}"
+  },
+  "^*": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "Expected atom at position 1\n    ^*\n     ^",
+    "input": "^*"
+  },
+  "$+": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "Expected atom at position 1\n    $+\n     ^",
+    "input": "$+"
+  },
+  "\\b?": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "Expected atom at position 2\n    \\b?\n      ^",
+    "input": "\\b?"
+  },
+  "\\B{1}": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "Expected atom at position 2\n    \\B{1}\n      ^",
+    "input": "\\B{1}"
   }
 }


### PR DESCRIPTION
The Annex B allows quantifiable assertions followed by a quantifier without the atom. Previously we allowed all assertions followed by quantifiers, rendering invalid regex such as `^*` being parsed successfully.