### PR TITLE
fix: descend ClassStringDisjunction from ClassSetOperand

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -1027,8 +1027,6 @@
           range: [res.range[0] - 1, res.range[1]],
           raw: res[0]
         });
-      } else if (features.unicodeSet && hasUnicodeSetFlag && match('q{')) {
-        return parseClassStringDisjunction();
       }
       return false;
     }
@@ -1471,7 +1469,9 @@
         // NestedClass ::
         //      ...
         //      \ CharacterClassEscape[+U, +V]
-        if (res = parseClassEscape()) {
+        if (match('q{')) {
+          return parseClassStringDisjunction();
+        } else if (res = parseClassEscape()) {
           start = res;
         } else if (res = parseClassSetCharacterEscapedHelper()) {
           return res;

--- a/test/test-data-unicode-set.json
+++ b/test/test-data-unicode-set.json
@@ -1627,5 +1627,11 @@
     "name": "SyntaxError",
     "message": "Invalid set operation in character class at position 3\n    [~~]\n       ^",
     "input": "[~~]"
+  },
+  "\\q{a}": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "atomEscape at position 1\n    \\q{a}\n     ^",
+    "input": "\\q{a}"
   }
 }


### PR DESCRIPTION
Previously it was descended from `CharacterClassEscape`, rendering invalid regex `/\q{a}/v` being successfully parsed.