### PR TITLE
annex-b: \ can be ClassAtomNoDash if followed by c

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -1386,6 +1386,9 @@
       // ClassAtomNoDash ::
       //      SourceCharacter but not one of \ or ] or -
       //      \ ClassEscape
+      //
+      // ClassAtomNoDash (Annex B)::
+      //      \ [lookahead = c] 
 
       var res;
       if (res = matchReg(/^[^\\\]-]/)) {
@@ -1393,6 +1396,9 @@
       } else if (match('\\')) {
         res = parseClassEscape();
         if (!res) {
+          if (!isUnicodeMode && lookahead() == 'c') {
+            return createCharacter('\\');
+          }
           bail('classEscape');
         }
 

--- a/test/test-data-unicode.json
+++ b/test/test-data-unicode.json
@@ -1872,5 +1872,11 @@
     "name": "SyntaxError",
     "message": "Expected atom at position 2\n    \\B{1}\n      ^",
     "input": "\\B{1}"
+  },
+  "[\\c]": {
+    "type": "error",
+    "name": "SyntaxError",
+    "message": "classEscape at position 2\n    [\\c]\n      ^",
+    "input": "[\\c]"
   }
 }

--- a/test/test-data.json
+++ b/test/test-data.json
@@ -38627,6 +38627,38 @@
     ],
     "raw": ".(?!.){2,3}"
   },
+  "[\\c]": {
+    "type": "characterClass",
+    "kind": "union",
+    "body": [
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 92,
+        "range": [
+          1,
+          2
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          2,
+          3
+        ],
+        "raw": "c"
+      }
+    ],
+    "negative": false,
+    "range": [
+      0,
+      4
+    ],
+    "raw": "[\\c]"
+  },
   "^*": {
     "type": "error",
     "name": "SyntaxError",


### PR DESCRIPTION
After this issue is fixed, the last remaining spec compliance issue is that when `uv` flag is not enabled, the annex B will first parse the pattern with `~NamedCaptureGroups`, if the result contains a group name, then reparse the pattern with `+NamedCaptureGroups`. Currently we always parse pattern with `+NamedCaptureGroups` as long as the feature flag is enabled.

This means that the following RegExps are valid:
```js
/\k/
/\k<a/
/\k<a>/
```
And the following regexps are invalid:
```js
/(?<a>a)\k<a>\k/
/(?<a>a)\k<a>\k</
/(?<a>a)\k<a>\k<a>/
```

To do this I think we have to either parse a regex twice as spec required or figured out how to reinterpret named capture groups into an array of characters or vice. Since this change will not be very trivial, I suggest we cut a new release after this PR gets merged.